### PR TITLE
It was move function that load plugin textdomain to woocommerce-merca…

### DIFF
--- a/includes/module/WC_WooMercadoPago_Init.php
+++ b/includes/module/WC_WooMercadoPago_Init.php
@@ -19,7 +19,7 @@ class WC_WooMercadoPago_Init
         $text_domain = 'woocommerce-mercadopago';
         $locale = apply_filters('plugin_locale', get_locale(), $text_domain);
 
-        $original_language_file = dirname(__FILE__) . '/i18n/languages/woocommerce-mercadopago-' . $locale . '.mo';
+        $original_language_file = dirname(__FILE__) . '/../../i18n/languages/woocommerce-mercadopago-' . $locale . '.mo';
 
         // Unload the translation for the text domain of the plugin
         unload_textdomain($text_domain);

--- a/includes/module/WC_WooMercadoPago_Init.php
+++ b/includes/module/WC_WooMercadoPago_Init.php
@@ -8,6 +8,26 @@ class WC_WooMercadoPago_Init
 {
 
     /**
+     * Load plugin text domain.
+     *
+     * Need to require here before test for PHP version.
+     *
+     * @since 3.0.1
+     */
+    public static function woocommerce_mercadopago_load_plugin_textdomain()
+    {
+        $text_domain = 'woocommerce-mercadopago';
+        $locale = apply_filters('plugin_locale', get_locale(), $text_domain);
+
+        $original_language_file = dirname(__FILE__) . '/i18n/languages/woocommerce-mercadopago-' . $locale . '.mo';
+
+        // Unload the translation for the text domain of the plugin
+        unload_textdomain($text_domain);
+        // Load first the override file
+        load_textdomain($text_domain, $original_language_file);
+    }
+
+    /**
      * Notice about unsupported PHP version.
      *
      * @since 3.0.1
@@ -68,6 +88,7 @@ class WC_WooMercadoPago_Init
     public static function woocommerce_mercadopago_init()
     {
 
+        self::woocommerce_mercadopago_load_plugin_textdomain();
         require_once dirname(__FILE__) . '../../admin/notices/WC_WooMercadoPago_Notices.php';
         WC_WooMercadoPago_Notices::initMercadopagoNnotice();
 

--- a/includes/module/WC_WooMercadoPago_Init.php
+++ b/includes/module/WC_WooMercadoPago_Init.php
@@ -8,26 +8,6 @@ class WC_WooMercadoPago_Init
 {
 
     /**
-     * Load plugin text domain.
-     *
-     * Need to require here before test for PHP version.
-     *
-     * @since 3.0.1
-     */
-    public static function woocommerce_mercadopago_load_plugin_textdomain()
-    {
-        $text_domain = 'woocommerce-mercadopago';
-        $locale = apply_filters('plugin_locale', get_locale(), $text_domain);
-
-        $original_language_file = dirname(__FILE__) . '/i18n/languages/woocommerce-mercadopago-' . $locale . '.mo';
-
-        // Unload the translation for the text domain of the plugin
-        unload_textdomain($text_domain);
-        // Load first the override file
-        load_textdomain($text_domain, $original_language_file);
-    }
-
-    /**
      * Notice about unsupported PHP version.
      *
      * @since 3.0.1
@@ -90,8 +70,6 @@ class WC_WooMercadoPago_Init
 
         require_once dirname(__FILE__) . '../../admin/notices/WC_WooMercadoPago_Notices.php';
         WC_WooMercadoPago_Notices::initMercadopagoNnotice();
-
-        add_action('plugins_loaded',  array(__CLASS__, 'woocommerce_mercadopago_load_plugin_textdomain'));
 
         // Check for PHP version and throw notice.
         if (version_compare(PHP_VERSION, '5.6', '<=')) {

--- a/woocommerce-mercadopago.php
+++ b/woocommerce-mercadopago.php
@@ -29,28 +29,6 @@ if (!function_exists('is_plugin_active')) {
     include_once ABSPATH . 'wp-admin/includes/plugin.php';
 }
 
-/**
- * Load plugin text domain.
- *
- * Need to require here before test for PHP version.
- *
- * @since 3.0.1
- */
-function woocommerce_mercadopago_load_plugin_textdomain()
-{
-    $text_domain = 'woocommerce-mercadopago';
-    $locale = apply_filters('plugin_locale', get_locale(), $text_domain);
-
-    $original_language_file = dirname(__FILE__) . '/i18n/languages/woocommerce-mercadopago-' . $locale . '.mo';
-
-    // Unload the translation for the text domain of the plugin
-    unload_textdomain($text_domain);
-    // Load first the override file
-    load_textdomain($text_domain, $original_language_file);
-}
-
-add_action( 'plugins_loaded', 'woocommerce_mercadopago_load_plugin_textdomain' );
-
 if (!class_exists('WC_WooMercadoPago_Init')) {
     include_once dirname(__FILE__) . '/includes/module/WC_WooMercadoPago_Init.php';
     add_action('plugins_loaded', array('WC_WooMercadoPago_Init', 'woocommerce_mercadopago_init'));

--- a/woocommerce-mercadopago.php
+++ b/woocommerce-mercadopago.php
@@ -29,6 +29,28 @@ if (!function_exists('is_plugin_active')) {
     include_once ABSPATH . 'wp-admin/includes/plugin.php';
 }
 
+/**
+ * Load plugin text domain.
+ *
+ * Need to require here before test for PHP version.
+ *
+ * @since 3.0.1
+ */
+function woocommerce_mercadopago_load_plugin_textdomain()
+{
+    $text_domain = 'woocommerce-mercadopago';
+    $locale = apply_filters('plugin_locale', get_locale(), $text_domain);
+
+    $original_language_file = dirname(__FILE__) . '/i18n/languages/woocommerce-mercadopago-' . $locale . '.mo';
+
+    // Unload the translation for the text domain of the plugin
+    unload_textdomain($text_domain);
+    // Load first the override file
+    load_textdomain($text_domain, $original_language_file);
+}
+
+add_action( 'plugins_loaded', 'woocommerce_mercadopago_load_plugin_textdomain' );
+
 if (!class_exists('WC_WooMercadoPago_Init')) {
     include_once dirname(__FILE__) . '/includes/module/WC_WooMercadoPago_Init.php';
     add_action('plugins_loaded', array('WC_WooMercadoPago_Init', 'woocommerce_mercadopago_init'));


### PR DESCRIPTION
Troquei o local onde é carregada as traduções, infelizmente esse método que utilizamos hoje é acionado pelo hook de plugins_loaded e deve ficar no primeiro arquivo. 