### PR TITLE
Fixed logic about stock manager

### DIFF
--- a/includes/stock/WC_WooMercadoPago_Stock_Manager.php
+++ b/includes/stock/WC_WooMercadoPago_Stock_Manager.php
@@ -14,12 +14,16 @@ class WC_WooMercadoPago_Stock_Manager
      */
     public function __construct()
     {
+        // MP status pending logic
         add_action('woocommerce_order_status_pending_to_cancelled', array('WC_WooMercadoPago_Stock_Manager', 'restore_stock_item'), 10, 1);
-        add_action('woocommerce_order_status_processing_to_cancelled', array('WC_WooMercadoPago_Stock_Manager', 'restore_stock_item'), 10, 1);
-        add_action('woocommerce_order_status_completed_to_cancelled', array('WC_WooMercadoPago_Stock_Manager', 'restore_stock_item'), 10, 1);
+        add_action('woocommerce_order_status_pending_to_failed', array('WC_WooMercadoPago_Stock_Manager', 'restore_stock_item'), 10, 1);
+
+        // Mp status in_process logic
         add_action('woocommerce_order_status_on-hold_to_cancelled', array('WC_WooMercadoPago_Stock_Manager', 'restore_stock_item'), 10, 1);
+        add_action('woocommerce_order_status_on-hold_to_failed', array('WC_WooMercadoPago_Stock_Manager', 'restore_stock_item'), 10, 1);
+
+        // Mp status approved logic
         add_action('woocommerce_order_status_processing_to_refunded', array('WC_WooMercadoPago_Stock_Manager', 'restore_stock_item'), 10, 1);
-        add_action('woocommerce_order_status_completed_to_refunded', array('WC_WooMercadoPago_Stock_Manager', 'restore_stock_item'), 10, 1);
         add_action('woocommerce_order_status_on-hold_to_refunded', array('WC_WooMercadoPago_Stock_Manager', 'restore_stock_item'), 10, 1);
     }
 
@@ -28,9 +32,18 @@ class WC_WooMercadoPago_Stock_Manager
      */
     public static function restore_stock_item($order_id)
     {
-        $order = new WC_Order($order_id);
+        $order = wc_get_order($order_id);
 
-        if (!get_option('woocommerce_manage_stock') == 'yes' && !sizeof($order->get_items()) > 0) {
+        if (!$order || 'yes' !== get_option('woocommerce_manage_stock') || !apply_filters('woocommerce_can_reduce_order_stock', true, $order)) {
+            return;
+        }
+
+        if ($order->get_payment_method() != 'woo-mercado-pago-ticket') {
+            return;
+        }
+
+        $mp_ticket_settings = get_option('woocommerce_woo-mercado-pago-ticket_settings');
+        if (empty($mp_ticket_settings) || !in_array('stock_reduce_mode', $mp_ticket_settings) || $mp_ticket_settings['stock_reduce_mode'] == 'no') {
             return;
         }
 


### PR DESCRIPTION
Logica ajustada para seguir os estados de pagamentos segundo Mercado Pago.
![image](https://user-images.githubusercontent.com/12517532/92641738-8dc93e80-f2b5-11ea-8c22-4d3a40978714.png)

**De para de status Mercado pago VS WooCommerce**
            'pending' => 'pending',
            'approved' => 'processing',
            'inprocess' => 'on_hold',
            'inmediation' => 'on_hold',
            'rejected' => 'failed',
            'cancelled' => 'cancelled',
            'refunded' => 'refunded',
            'chargedback' => 'refunded'

Adicionado IF impedindo que o stock altere para outros meios de pagamento.