### PR TITLE
New Release 4.5.0

### DIFF
--- a/i18n/languages/woocommerce-mercadopago.pot
+++ b/i18n/languages/woocommerce-mercadopago.pot
@@ -66,7 +66,7 @@ msgstr ""
 msgid "Cancel order"
 msgstr ""
 
-#: includes/module/WC_WooMercadoPago_Module.php:241, includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:399
+#: includes/module/WC_WooMercadoPago_Module.php:241, includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:364
 msgid "Fill in your credentials to enable payment methods."
 msgstr ""
 
@@ -378,11 +378,11 @@ msgstr ""
 msgid "installment"
 msgstr ""
 
-#: includes/payments/WC_WooMercadoPago_BasicGateway.php:598, includes/payments/WC_WooMercadoPago_BasicGateway.php:598, includes/payments/WC_WooMercadoPago_BasicGateway.php:585, includes/payments/WC_WooMercadoPago_BasicGateway.php:585, includes/payments/WC_WooMercadoPago_CustomGateway.php:347, includes/payments/WC_WooMercadoPago_CustomGateway.php:347, includes/payments/WC_WooMercadoPago_CustomGateway.php:335, includes/payments/WC_WooMercadoPago_CustomGateway.php:335, includes/payments/WC_WooMercadoPago_TicketGateway.php:446, includes/payments/WC_WooMercadoPago_TicketGateway.php:446, includes/payments/WC_WooMercadoPago_TicketGateway.php:433, includes/payments/WC_WooMercadoPago_TicketGateway.php:433, includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:134, includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:132
+#: includes/payments/WC_WooMercadoPago_BasicGateway.php:598, includes/payments/WC_WooMercadoPago_BasicGateway.php:598, includes/payments/WC_WooMercadoPago_BasicGateway.php:585, includes/payments/WC_WooMercadoPago_BasicGateway.php:585, includes/payments/WC_WooMercadoPago_CustomGateway.php:347, includes/payments/WC_WooMercadoPago_CustomGateway.php:347, includes/payments/WC_WooMercadoPago_CustomGateway.php:335, includes/payments/WC_WooMercadoPago_CustomGateway.php:335, includes/payments/WC_WooMercadoPago_TicketGateway.php:446, includes/payments/WC_WooMercadoPago_TicketGateway.php:446, includes/payments/WC_WooMercadoPago_TicketGateway.php:433, includes/payments/WC_WooMercadoPago_TicketGateway.php:433, includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:100, includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:98
 msgid "discount of"
 msgstr ""
 
-#: includes/payments/WC_WooMercadoPago_BasicGateway.php:603, includes/payments/WC_WooMercadoPago_BasicGateway.php:603, includes/payments/WC_WooMercadoPago_BasicGateway.php:590, includes/payments/WC_WooMercadoPago_BasicGateway.php:590, includes/payments/WC_WooMercadoPago_CustomGateway.php:352, includes/payments/WC_WooMercadoPago_CustomGateway.php:352, includes/payments/WC_WooMercadoPago_CustomGateway.php:340, includes/payments/WC_WooMercadoPago_CustomGateway.php:340, includes/payments/WC_WooMercadoPago_TicketGateway.php:451, includes/payments/WC_WooMercadoPago_TicketGateway.php:451, includes/payments/WC_WooMercadoPago_TicketGateway.php:438, includes/payments/WC_WooMercadoPago_TicketGateway.php:438, includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:136
+#: includes/payments/WC_WooMercadoPago_BasicGateway.php:603, includes/payments/WC_WooMercadoPago_BasicGateway.php:603, includes/payments/WC_WooMercadoPago_BasicGateway.php:590, includes/payments/WC_WooMercadoPago_BasicGateway.php:590, includes/payments/WC_WooMercadoPago_CustomGateway.php:352, includes/payments/WC_WooMercadoPago_CustomGateway.php:352, includes/payments/WC_WooMercadoPago_CustomGateway.php:340, includes/payments/WC_WooMercadoPago_CustomGateway.php:340, includes/payments/WC_WooMercadoPago_TicketGateway.php:451, includes/payments/WC_WooMercadoPago_TicketGateway.php:451, includes/payments/WC_WooMercadoPago_TicketGateway.php:438, includes/payments/WC_WooMercadoPago_TicketGateway.php:438, includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:102
 msgid "fee of"
 msgstr ""
 
@@ -1169,23 +1169,23 @@ msgstr ""
 msgid "Discount for coupon %s"
 msgstr ""
 
-#: includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:132
+#: includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:98
 msgid " and fee of"
 msgstr ""
 
-#: includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:359
+#: includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:324
 msgid "<b>Public Key</b> production credential is invalid. Review the field to receive real payments."
 msgstr ""
 
-#: includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:369
+#: includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:334
 msgid "<b>Public Key</b> test credential is invalid. Review the field to perform tests in your store."
 msgstr ""
 
-#: includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:379
+#: includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:344
 msgid "<b>Access Token</b> production credential is invalid. Remember that it must be complete to receive real payments."
 msgstr ""
 
-#: includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:389
+#: includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php:354
 msgid "<b>Access Token</b> test credential is invalid. Review the field to perform tests in your store."
 msgstr ""
 

--- a/includes/module/sdk/lib/MP.php
+++ b/includes/module/sdk/lib/MP.php
@@ -690,29 +690,6 @@ class MP
         return $result;
     }
 
-    //=== MODULE ANALYTICS FUNCTIONS ===
-
-    /**
-     * @param $module_info
-     * @return array|null
-     * @throws WC_WooMercadoPago_Exception
-     */
-    public function analytics_save_settings($module_info)
-    {
-        try {
-            $request = array(
-                'uri'  => '/modules/tracking/settings?access_token=' . $this->get_access_token(),
-                'data' => $module_info,
-            );
-
-            $result = MPRestClient::post($request);
-        } catch (Exception $e) {
-            $result = null;
-        }
-
-        return $result;
-    }
-
     /**
      * @param null $payment
      */

--- a/includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php
+++ b/includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php
@@ -67,40 +67,6 @@ abstract class WC_WooMercadoPago_Hook_Abstract
     }
 
     /**
-     * Analytics Save
-     */
-    public function send_settings_mp()
-    {
-        if (!empty($this->payment->getAccessToken()) && !empty($this->siteId)) {
-            if (!$this->testUser) {
-                $this->payment->mp->analytics_save_settings($this->define_settings_to_send());
-            }
-        }
-    }
-
-    /**
-     * @return array
-     */
-    public function define_settings_to_send()
-    {
-        $infra_data = WC_WooMercadoPago_Module::get_common_settings();
-        switch (get_class($this->payment)) {
-            case 'WC_WooMercadoPago_BasicGateway':
-                $infra_data['checkout_basic'] = ($this->payment->settings['enabled'] == 'yes' ? 'true' : 'false');
-                break;
-            case 'WC_WooMercadoPago_CustomGateway':
-                $infra_data['checkout_custom_credit_card'] = ($this->payment->settings['enabled'] == 'yes' ? 'true' : 'false');
-                $infra_data['checkout_custom_credit_card_coupon'] = ($this->payment->settings['coupon_mode'] == 'yes' ? 'true' : 'false');
-                break;
-            case 'WC_WooMercadoPago_TicketGateway':
-                $infra_data['checkout_custom_ticket'] = ($this->payment->settings['enabled'] == 'yes' ? 'true' : 'false');
-                $infra_data['checkout_custom_ticket_coupon'] = ($this->payment->settings['coupon_mode'] == 'yes' ? 'true' : 'false');
-                break;
-        }
-        return $infra_data;
-    }
-
-    /**
      * @param $title
      * @return string
      */
@@ -212,7 +178,6 @@ abstract class WC_WooMercadoPago_Hook_Abstract
                 $this->payment->settings[$key] = $value;
             }
         }
-        $this->send_settings_mp();
 
         $result = update_option($this->payment->get_option_key(), apply_filters('woocommerce_settings_api_sanitized_fields_' . $this->payment->id, $this->payment->settings));
 


### PR DESCRIPTION
= v4.5.0 (26/10/2020) =
• Features
   
   • Compatibility with WooCommerce v4.6.x
   • Improved security (added access token in the header for all calls to Mercado Livre and Mercado Pago endpoints)
   • Add new endpoint to validate Access Token and Public key to substitute old process to validation
   • Improved performance with CSS minification

• Bug fixes
   
   • Fixed conflict with wc-api webhook and Mercado Pago webhook/IPN.
   • Fixed alert in currency conversion
   • Fixed tranlate in currency conversion
   • Bug fixed when updating orders that have two or more payments associated.