### PR TITLE
[WooCommerce][PPWP-207] - Mostrar código pix no painel do cliente para consulta posterior

### DIFF
--- a/includes/payments/class-wc-woomercadopago-pix-gateway.php
+++ b/includes/payments/class-wc-woomercadopago-pix-gateway.php
@@ -627,71 +627,71 @@ class WC_WooMercadoPago_Pix_Gateway extends WC_WooMercadoPago_Payment_Abstract {
 	}
 
 	/**
-     * Get pix template
-     *
-     * @param object $order Order.
-     * @return string
-     */
-    public static function get_pix_template( $order) {
-    
-        $pix_on = get_post_meta( $order->get_id(), 'pix_on' );
-    
-        $pix_on = (int) array_pop( $pix_on );
-        
-        if ( 1 === $pix_on ) {
-          
-            $mp_pix_qr_code = get_post_meta( $order->get_id(), 'mp_pix_qr_code' );
-            $mp_pix_qr_base64 = get_post_meta( $order->get_id(), 'mp_pix_qr_base64' );
-            $checkout_pix_date_expiration = get_post_meta($order->get_id(), 'checkout_pix_date_expiration');
-    
-            $qr_code         = array_pop( $mp_pix_qr_code );
-            $qr_image        = array_pop( $mp_pix_qr_base64 );
-            $src             = 'data:image/jpeg;base64';
-            $expiration_date = array_pop( $checkout_pix_date_expiration );
-    
-            $pix_template = wc_get_template(
-                'pix/pix-image-template.php',
-                array(
-                    'src'                  => $src,
-                    'qr_image'             => $qr_image,
-                    'qr_code'              => $qr_code,
-                    'expiration_date'      => $expiration_date,
-                    'text_expiration_date' => __( 'Code valid for ', 'woocommerce-mercadopago' ),
-                ),
-                '',
-                WC_WooMercadoPago_Module::get_templates_path()
-            );
-    
-            return $pix_template;
-        }
-    
-    }
-      
-    /**
-     * Get pix template to send via email
-     *
-     * @param object $order Order.
-     * @param bool $sent_to_admin.
-     * @param bool $plain_text.
-     * @param $email
-     * @return string|array
-     */
-      public static function get_pix_template_email( $order, $sent_to_admin, $plain_text, $email ) {
-        
-        return self::get_pix_template( $order );
-    
-    }
-      
-    /**
-     * Get pix template to show in order details
-     *
-     * @param object $order Order.
-     * @return string|array
-     */
-      public static function get_pix_template_order_details( $order ) {
-        
-        return self::get_pix_template( $order );
-    
-    }
+	 * Get pix template
+	 *
+	 * @param object $order Order.
+	 * @return string
+	 */
+	public static function get_pix_template( $order ) {
+
+		$pix_on = get_post_meta( $order->get_id(), 'pix_on' );
+
+		$pix_on = (int) array_pop( $pix_on );
+
+		if ( 1 === $pix_on ) {
+
+			$mp_pix_qr_code               = get_post_meta( $order->get_id(), 'mp_pix_qr_code' );
+			$mp_pix_qr_base64             = get_post_meta( $order->get_id(), 'mp_pix_qr_base64' );
+			$checkout_pix_date_expiration = get_post_meta($order->get_id(), 'checkout_pix_date_expiration');
+
+			$qr_code         = array_pop( $mp_pix_qr_code );
+			$qr_image        = array_pop( $mp_pix_qr_base64 );
+			$src             = 'data:image/jpeg;base64';
+			$expiration_date = array_pop( $checkout_pix_date_expiration );
+
+			$pix_template = wc_get_template(
+				'pix/pix-image-template.php',
+				array(
+					'src'                  => $src,
+					'qr_image'             => $qr_image,
+					'qr_code'              => $qr_code,
+					'expiration_date'      => $expiration_date,
+					'text_expiration_date' => __( 'Code valid for ', 'woocommerce-mercadopago' ),
+				),
+				'',
+				WC_WooMercadoPago_Module::get_templates_path()
+			);
+
+			return $pix_template;
+		}
+
+	}
+
+	/**
+	 * Get pix template to send via email
+	 *
+	 * @param object $order Order.
+	 * @param bool $sent_to_admin.
+	 * @param bool $plain_text.
+	 * @param $email
+	 * @return string|array
+	 */
+	public static function get_pix_template_email( $order, $sent_to_admin, $plain_text, $email ) {
+
+		return self::get_pix_template( $order );
+
+	}
+
+	/**
+	 * Get pix template to show in order details
+	 *
+	 * @param object $order Order.
+	 * @return string|array
+	 */
+	public static function get_pix_template_order_details( $order ) {
+
+		return self::get_pix_template( $order );
+
+	}
 
 }

--- a/templates/pix/pix-image-template.php
+++ b/templates/pix/pix-image-template.php
@@ -44,12 +44,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 
 	<div style="margin-left: auto; 
-            margin-right: auto;
-            width: 320px;
-            word-break: break-word;
-            font-size: 10px;">      
-        <p>
-            <?php esc_html_e( $qr_code, 'woocommerce-mercadopago' ); ?>
-        </p>
-    </div>
+			margin-right: auto;
+			width: 320px;
+			word-break: break-word;
+			font-size: 10px;">      
+		<p>
+			<?php esc_html_e( $qr_code, 'woocommerce-mercadopago' ); ?>
+		</p>
+	</div>
 </div>


### PR DESCRIPTION
Neste PR deixei disponível a imagem QR do pix nos detalhes do pedido, para consulta posterior ,nos casos em que o cliente deixa a tela de sucesso da compra.