### PR TITLE
Novo Fluxo de Testes - Inserindo função de chaveamento para o link do devsite

### DIFF
--- a/includes/payments/class-wc-woomercadopago-basic-gateway.php
+++ b/includes/payments/class-wc-woomercadopago-basic-gateway.php
@@ -572,8 +572,7 @@ class WC_WooMercadoPago_Basic_Gateway extends WC_WooMercadoPago_Payment_Abstract
 			}
 		}
 
-		// TODO: Remover link provisório
-		$test_mode_rules_link = 'https://mercadopago.com.' . $this->get_country_domain_by_meli_acronym($this->checkout_country);
+		$test_mode_rules_link = $this->get_mp_devsite_link($this->checkout_country);
 		$parameters           = array(
 			'checkout_alert_test_mode' => $this->is_production_mode()
 				? ''

--- a/includes/payments/class-wc-woomercadopago-custom-gateway.php
+++ b/includes/payments/class-wc-woomercadopago-custom-gateway.php
@@ -363,8 +363,7 @@ class WC_WooMercadoPago_Custom_Gateway extends WC_WooMercadoPago_Payment_Abstrac
 			$currency_ratio = WC_WooMercadoPago_Helpers_CurrencyConverter::DEFAULT_RATIO;
 		}
 
-		// TODO: Remover link provisório
-		$test_mode_rules_link = 'https://mercadopago.com.' . $this->get_country_domain_by_meli_acronym($this->checkout_country);
+		$test_mode_rules_link = $this->get_mp_devsite_link($this->checkout_country);
 		$parameters           = array(
 			'checkout_alert_test_mode' => $this->is_production_mode()
 			? ''

--- a/includes/payments/class-wc-woomercadopago-payment-abstract.php
+++ b/includes/payments/class-wc-woomercadopago-payment-abstract.php
@@ -1951,13 +1951,13 @@ class WC_WooMercadoPago_Payment_Abstract extends WC_Payment_Gateway {
 	 */
 	public function get_mp_devsite_link( $country ) {
 		$country_links = [
-			'mla' => 'https://rebrand.ly/l5bt0p3',
-			'mlb' => 'https://rebrand.ly/g20teif',
-			'mlc' => 'https://rebrand.ly/6drvoof',
-			'mco' => 'https://rebrand.ly/o5av2xn',
-			'mlm' => 'https://rebrand.ly/ajrdsp3',
-			'mpe' => 'https://rebrand.ly/m16d4v4',
-			'mlu' => 'https://rebrand.ly/0a2ngts',
+			'mla' => 'https://rebrand.ly/test-woo-ar',
+			'mlb' => 'https://rebrand.ly/test-woo-br',
+			'mlc' => 'https://rebrand.ly/test-woo-cl',
+			'mco' => 'https://rebrand.ly/test-woo-co',
+			'mlm' => 'https://rebrand.ly/test-woo-mx',
+			'mpe' => 'https://rebrand.ly/test-woo-pe',
+			'mlu' => 'https://rebrand.ly/test-woo-uy',
 		];
 		$link          = array_key_exists($country, $country_links) ? $country_links[$country] : $country_links['mla'];
 

--- a/includes/payments/class-wc-woomercadopago-payment-abstract.php
+++ b/includes/payments/class-wc-woomercadopago-payment-abstract.php
@@ -1941,4 +1941,26 @@ class WC_WooMercadoPago_Payment_Abstract extends WC_Payment_Gateway {
 
 		return $countries[$meliAcronym];
 	}
+
+	/**
+	 * Get Mercado Pago Devsite Page Link
+	 *
+	 * @param String $country Country Acronym
+	 *
+	 * @return String
+	 */
+	public function get_mp_devsite_link( $country ) {
+		$country_links = [
+			'mla' => 'https://rebrand.ly/l5bt0p3',
+			'mlb' => 'https://rebrand.ly/g20teif',
+			'mlc' => 'https://rebrand.ly/6drvoof',
+			'mco' => 'https://rebrand.ly/o5av2xn',
+			'mlm' => 'https://rebrand.ly/ajrdsp3',
+			'mpe' => 'https://rebrand.ly/m16d4v4',
+			'mlu' => 'https://rebrand.ly/0a2ngts',
+		];
+		$link          = array_key_exists($country, $country_links) ? $country_links[$country] : $country_links['mla'];
+
+		return $link;
+	}
 }


### PR DESCRIPTION
## Descrição
No momento estamos utilizando [rebrandly](https://www.rebrandly.com/) para após a publicação oficial da nova documentação do devsite do Mercado Pago, através da plataforma terceira, alterar o destino do link que no momento será para o [devsite do WooCommerce](https://www.mercadopago.com.br/developers/pt/guides/plugins/woocommerce/introduction) chaveado de acordo com o país do seller.