### PR TITLE
Correções - Release 5.4.0

### DIFF
--- a/i18n/languages/woocommerce-mercadopago.pot
+++ b/i18n/languages/woocommerce-mercadopago.pot
@@ -974,19 +974,19 @@ msgstr ""
 msgid "%s"
 msgstr ""
 
-#: ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1876, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1876, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1876
+#: ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1877, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1877, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1877
 msgid "All Mercado Pago payment methods are in Production Mode"
 msgstr ""
 
-#: ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1877, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1877, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1877
+#: ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1878, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1878, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1878
 msgid "All Mercado Pago payment methods are in Test Mode"
 msgstr ""
 
-#: ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1879, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1879, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1879
+#: ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1880, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1880, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1880
 msgid "Your store is ready to receive payments from customers."
 msgstr ""
 
-#: ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1880, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1880, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1880
+#: ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1881, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1881, ../../includes/payments/class-wc-woomercadopago-payment-abstract.php:1881
 msgid "Your customers will not be able to make purchases while in Test Mode."
 msgstr ""
 
@@ -1639,7 +1639,7 @@ msgstr ""
 msgid "Copy code"
 msgstr ""
 
-#: ../../includes/module/sdk/lib/class-mp.php:601, ../../includes/module/sdk/lib/class-mp.php:645, ../../includes/module/sdk/lib/class-mp.php:601, ../../includes/module/sdk/lib/class-mp.php:645, ../../includes/module/sdk/lib/class-mp.php:601, ../../includes/module/sdk/lib/class-mp.php:645
+#: ../../includes/module/sdk/lib/class-mp.php:599, ../../includes/module/sdk/lib/class-mp.php:643, ../../includes/module/sdk/lib/class-mp.php:599, ../../includes/module/sdk/lib/class-mp.php:643, ../../includes/module/sdk/lib/class-mp.php:599, ../../includes/module/sdk/lib/class-mp.php:643
 msgid "Response from cache"
 msgstr ""
 

--- a/includes/admin/hooks/class-wc-woomercadopago-hook-order-details.php
+++ b/includes/admin/hooks/class-wc-woomercadopago-hook-order-details.php
@@ -473,13 +473,13 @@ class WC_WooMercadoPago_Hook_Order_Details {
 	 */
 	public function get_mp_devsite_link( $country ) {
 		$country_links = [
-			'mla' => 'https://rebrand.ly/l5bt0p3',
-			'mlb' => 'https://rebrand.ly/g20teif',
-			'mlc' => 'https://rebrand.ly/6drvoof',
-			'mco' => 'https://rebrand.ly/o5av2xn',
-			'mlm' => 'https://rebrand.ly/ajrdsp3',
-			'mpe' => 'https://rebrand.ly/m16d4v4',
-			'mlu' => 'https://rebrand.ly/0a2ngts',
+			'mla' => 'https://www.mercadopago.com.ar/developers/es/guides/plugins/woocommerce/sales-processing#bookmark_motivos_de_las_recusas',
+			'mlb' => 'https://www.mercadopago.com.br/developers/pt/guides/plugins/woocommerce/sales-processing#bookmark_motivos_de_recusas',
+			'mlc' => 'https://www.mercadopago.cl/developers/es/guides/plugins/woocommerce/sales-processing#bookmark_motivos_de_las_recusas',
+			'mco' => 'https://www.mercadopago.com.co/developers/es/guides/plugins/woocommerce/sales-processing#bookmark_motivos_de_las_recusas',
+			'mlm' => 'https://www.mercadopago.com.mx/developers/es/guides/plugins/woocommerce/sales-processing#bookmark_motivos_de_las_recusas',
+			'mpe' => 'https://www.mercadopago.com.pe/developers/es/guides/plugins/woocommerce/sales-processing#bookmark_motivos_de_las_recusas',
+			'mlu' => 'https://www.mercadopago.com.uy/developers/es/guides/plugins/woocommerce/sales-processing#bookmark_motivos_de_las_recusas',
 		];
 		$link          = array_key_exists($country, $country_links) ? $country_links[$country] : $country_links['mla'];
 

--- a/includes/admin/hooks/class-wc-woomercadopago-hook-order-details.php
+++ b/includes/admin/hooks/class-wc-woomercadopago-hook-order-details.php
@@ -363,11 +363,11 @@ class WC_WooMercadoPago_Hook_Order_Details {
 
 		$last_payment_id    = end($payment_ids);
 		$is_production_mode = $order->get_meta( 'is_production_mode' );
-		$access_token       = 'no' === $is_production_mode
+		$access_token       = 'no' === $is_production_mode || ! $is_production_mode
 			? get_option( '_mp_access_token_test' )
 			: get_option( '_mp_access_token_prod' );
 		$mp                 = new MP($access_token);
-		$payment            = $mp->search_payment_v1(trim($last_payment_id));
+		$payment            = $mp->search_payment_v1(trim($last_payment_id), $access_token);
 
 		if ( ! $payment || ! $payment['status'] || 200 !== $payment['status'] ) {
 			return;

--- a/includes/module/sdk/lib/class-mp.php
+++ b/includes/module/sdk/lib/class-mp.php
@@ -128,7 +128,6 @@ class MP {
 	 * @throws WC_WooMercadoPago_Exception Get Access Token Exception.
 	 */
 	public function get_access_token() {
-
 		if ( isset( $this->ll_access_token ) && ! is_null( $this->ll_access_token ) ) {
 			return $this->ll_access_token;
 		}
@@ -170,12 +169,11 @@ class MP {
 	 * @return array|null
 	 * @throws WC_WooMercadoPago_Exception Search Payment V1 Exception.
 	 */
-	public function search_payment_v1( $id ) {
-
+	public function search_payment_v1( $id, $token = null ) {
 		$request = array(
 			'uri'    => '/v1/payments/' . $id,
 			'headers' => array(
-				'Authorization' => 'Bearer ' . $this->get_access_token(),
+				'Authorization' => 'Bearer ' . ( is_null($token) ? $this->get_access_token() : $token ),
 			)
 		);
 

--- a/includes/payments/class-wc-woomercadopago-payment-abstract.php
+++ b/includes/payments/class-wc-woomercadopago-payment-abstract.php
@@ -1854,13 +1854,13 @@ class WC_WooMercadoPago_Payment_Abstract extends WC_Payment_Gateway {
 			$key     = 'woocommerce_' . $gateway::get_id() . '_settings';
 			$options = get_option( $key );
 			if ( ! empty( $options ) ) {
-				if ( ! isset( $options['checkbox_checkout_test_mode'] ) || empty( $options['checkbox_checkout_test_mode'] ) ) {
-					continue;
-				}
-
 				$old_credential_is_prod                 = array_key_exists('checkout_credential_prod', $options) && isset($options['checkout_credential_prod']) ? $options['checkout_credential_prod'] : 'no';
 				$has_new_key                            = array_key_exists('checkbox_checkout_test_mode', $options) && isset($options['checkbox_checkout_test_mode']);
-				$options['checkbox_checkout_test_mode'] = $has_new_key ? $options['checkbox_checkout_test_mode'] : ( 'yes' === $old_credential_is_prod ? 'no' : 'yes' );
+				$options['checkbox_checkout_test_mode'] = $has_new_key && 'deprecated' === $old_credential_is_prod
+					? $options['checkbox_checkout_test_mode']
+					: ( 'yes' === $old_credential_is_prod ? 'no' : 'yes' );
+				$options['checkout_credential_prod']    = 'deprecated';
+
 				update_option( $key, apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $gateway::get_id(), $options ) );
 			}
 		}

--- a/includes/payments/class-wc-woomercadopago-payment-abstract.php
+++ b/includes/payments/class-wc-woomercadopago-payment-abstract.php
@@ -1954,13 +1954,13 @@ class WC_WooMercadoPago_Payment_Abstract extends WC_Payment_Gateway {
 	 */
 	public function get_mp_devsite_link( $country ) {
 		$country_links = [
-			'mla' => 'https://rebrand.ly/test-woo-ar',
-			'mlb' => 'https://rebrand.ly/test-woo-br',
-			'mlc' => 'https://rebrand.ly/test-woo-cl',
-			'mco' => 'https://rebrand.ly/test-woo-co',
-			'mlm' => 'https://rebrand.ly/test-woo-mx',
-			'mpe' => 'https://rebrand.ly/test-woo-pe',
-			'mlu' => 'https://rebrand.ly/test-woo-uy',
+			'mla' => 'https://www.mercadopago.com.ar/developers/es/guides/plugins/woocommerce/testing',
+			'mlb' => 'https://www.mercadopago.com.br/developers/pt/guides/plugins/woocommerce/testing',
+			'mlc' => 'https://www.mercadopago.cl/developers/es/guides/plugins/woocommerce/testing',
+			'mco' => 'https://www.mercadopago.com.co/developers/es/guides/plugins/woocommerce/testing',
+			'mlm' => 'https://www.mercadopago.com.mx/developers/es/guides/plugins/woocommerce/testing',
+			'mpe' => 'https://www.mercadopago.com.pe/developers/es/guides/plugins/woocommerce/testing',
+			'mlu' => 'https://www.mercadopago.com.uy/developers/es/guides/plugins/woocommerce/testing',
 		];
 		$link          = array_key_exists($country, $country_links) ? $country_links[$country] : $country_links['mla'];
 

--- a/woocommerce-mercadopago.php
+++ b/woocommerce-mercadopago.php
@@ -9,7 +9,7 @@
  * Text Domain: woocommerce-mercadopago
  * Domain Path: /i18n/languages/
  * WC requires at least: 3.0.0
- * WC tested up to: 5.5.2
+ * WC tested up to: 5.7
  *
  * @package MercadoPago
  */


### PR DESCRIPTION
# Pontos corrigidos

### Problema ao buscar pagamento na ordem do pedido
Atualmente exibimos uma alerta para informar mais detalhes sobre o status do pagamento nos detalhes do pedido. Da forma que é feita hoje, precisamos saber se o pedido foi feito em produção ou teste para encontrar o pagamento, porém o token que estava sendo usado não estava sendo de acordo com o modo de checkout que o pedido foi feito.

### Ao atualizar o plugin todos os checkouts vão automaticamente para modo de teste
Isso ocorria devido a um if que só fazia sentido na propriedade anterior para o modo de checkout e sempre estava sendo utilizado a nova propriedade que armazenava se era prod/test, ignorando a configuração anterior do seller.

### Link do devsite foi atualizado oficialmente
Não estamos mais utilizando uma plataforma terceira para intermediar os links.