### PR TITLE
Release v5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.1] - 2021-09-22
+### Changed
+- On the order page, the payment was fetched with the wrong token
+- When the plugin was updated the checkout mode visually went to test
+
 ## [5.4.0] - 2021-09-20
 ### Added
 - Performance improvements

--- a/changelog.log
+++ b/changelog.log
@@ -1,5 +1,10 @@
 CHANGELOG:
 == Changelog ==
+= v5.4.1 (22/09/2021) =
+* Bug fixes
+- On the order page, the payment was fetched with the wrong token
+- When the plugin was updated the checkout mode visually went to test
+
 = v5.4.0 (20/09/2021) =
 * Features
 - Performance improvements

--- a/i18n/languages/woocommerce-mercadopago-es_AR.po
+++ b/i18n/languages/woocommerce-mercadopago-es_AR.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.0\n"
+"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-mercadopago\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2021-09-20 09:36-0300\n"

--- a/i18n/languages/woocommerce-mercadopago-es_CL.po
+++ b/i18n/languages/woocommerce-mercadopago-es_CL.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.0\n"
+"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-mercadopago\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2021-09-20 09:36-0300\n"

--- a/i18n/languages/woocommerce-mercadopago-es_CO.po
+++ b/i18n/languages/woocommerce-mercadopago-es_CO.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.0\n"
+"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-mercadopago\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2021-09-20 09:36-0300\n"

--- a/i18n/languages/woocommerce-mercadopago-es_ES.po
+++ b/i18n/languages/woocommerce-mercadopago-es_ES.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.0\n"
+"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-mercadopago\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2021-09-20 09:36-0300\n"

--- a/i18n/languages/woocommerce-mercadopago-es_MX.po
+++ b/i18n/languages/woocommerce-mercadopago-es_MX.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.0\n"
+"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-mercadopago\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2021-09-20 09:35-0300\n"

--- a/i18n/languages/woocommerce-mercadopago-es_PE.po
+++ b/i18n/languages/woocommerce-mercadopago-es_PE.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.0\n"
+"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-mercadopago\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2021-09-20 09:36-0300\n"

--- a/i18n/languages/woocommerce-mercadopago-es_UY.po
+++ b/i18n/languages/woocommerce-mercadopago-es_UY.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Mercado Pago payments for WooCommerce plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.0\n"
+"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-mercadopago\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2021-09-20 09:35-0300\n"

--- a/i18n/languages/woocommerce-mercadopago-es_VE.po
+++ b/i18n/languages/woocommerce-mercadopago-es_VE.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.0\n"
+"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-mercadopago\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2021-09-20 09:36-0300\n"

--- a/i18n/languages/woocommerce-mercadopago-pt_BR.po
+++ b/i18n/languages/woocommerce-mercadopago-pt_BR.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.0\n"
+"Project-Id-Version: Mercado Pago payments for WooCommerce 5.4.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-mercadopago\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2021-09-17 15:44-0300\n"

--- a/includes/module/config/class-wc-woomercadopago-constants.php
+++ b/includes/module/config/class-wc-woomercadopago-constants.php
@@ -21,7 +21,7 @@ class WC_WooMercadoPago_Constants {
 	const PRODUCT_ID_DESKTOP = 'BT7OF5FEOO6G01NJK3QG';
 	const PRODUCT_ID_MOBILE  = 'BT7OFH09QS3001K5A0H0';
 	const PLATAFORM_ID       = 'bo2hnr2ic4p001kbgpt0';
-	const VERSION            = '5.4.0';
+	const VERSION            = '5.4.1';
 	const MIN_PHP            = 5.6;
 	const API_MP_BASE_URL    = 'https://api.mercadopago.com';
 	const PAYMENT_GATEWAYS   = array(

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pot": "node -e 'require(\"./main.js\").generatePotFiles()'",
     "lint": "jshint"
   },
-  "version": "5.4.0",
+  "version": "5.4.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercadopago/cart-woocommerce"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, mercadopago, woocommerce
 Requires at least: 4.9.10
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 5.4.0
+Stable tag: 5.4.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -129,6 +129,11 @@ Set up both the plugin and the checkouts you want to activate on your payment av
 Check out our <a href="https://www.mercadopago.com.br/developers/pt/plugins_sdks/plugins/official/woo-commerce/">official documentation</a> for more information on the specific fields to configure.
 
 == Changelog ==
+= v5.4.1 (22/09/2021) =
+* Bug fixes
+- On the order page, the payment was fetched with the wrong token
+- When the plugin was updated the checkout mode visually went to test
+
 = 5.4.0 (20/09/2021) =
 * Features
 - Performance improvements

--- a/woocommerce-mercadopago.php
+++ b/woocommerce-mercadopago.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mercado Pago payments for WooCommerce
  * Plugin URI: https://github.com/mercadopago/cart-woocommerce
  * Description: Configure the payment options and accept payments with cards, ticket and money of Mercado Pago account.
- * Version: 5.4.0
+ * Version: 5.4.1
  * Author: Mercado Pago
  * Author URI: https://developers.mercadopago.com/
  * Text Domain: woocommerce-mercadopago


### PR DESCRIPTION
## [5.4.1] - 2021-09-22
### Changed
- On the order page, the payment was fetched with the wrong token
- When the plugin was updated the checkout mode visually went to test