### PR TITLE
fix: 🐛 instance class before call method

### DIFF
--- a/includes/module/mercadopago-settings/class-wc-woomercadopago-mercadopago-settings.php
+++ b/includes/module/mercadopago-settings/class-wc-woomercadopago-mercadopago-settings.php
@@ -520,8 +520,7 @@ class WC_WooMercadoPago_MercadoPago_Settings {
 		try {
 			$payments_gateways          = WC_WooMercadoPago_Constants::PAYMENT_GATEWAYS;
 			$payment_gateway_properties = array();
-			$wc_country                 = WC_WooMercadoPago_Module::get_woocommerce_default_country();
-			$payment_methods            = WC_WooMercadoPago_Configs::get_available_payment_methods();
+			$payment_methods            = (new WC_WooMercadoPago_Configs)->get_available_payment_methods();
 
 			foreach ( $payments_gateways as $payment_gateway ) {
 				if ( ! in_array( $payment_gateway, $payment_methods, true ) ) {

--- a/includes/module/mercadopago-settings/class-wc-woomercadopago-mercadopago-settings.php
+++ b/includes/module/mercadopago-settings/class-wc-woomercadopago-mercadopago-settings.php
@@ -520,7 +520,7 @@ class WC_WooMercadoPago_MercadoPago_Settings {
 		try {
 			$payments_gateways          = WC_WooMercadoPago_Constants::PAYMENT_GATEWAYS;
 			$payment_gateway_properties = array();
-			$payment_methods            = (new WC_WooMercadoPago_Configs)->get_available_payment_methods();
+			$payment_methods            = ( new WC_WooMercadoPago_Configs() )->get_available_payment_methods();
 
 			foreach ( $payments_gateways as $payment_gateway ) {
 				if ( ! in_array( $payment_gateway, $payment_methods, true ) ) {


### PR DESCRIPTION
Um fixinho baseado nessa reclamação: https://wordpress.org/support/topic/integracao-woocommerce-e-mercado-pago-gerando-erro-critico-em-meu-site/

É que chamar qualquer método não estático, de forma estática, na versões inferiores a 7, eram possíveis. Agora no PHP 8, não.

https://php.watch/versions/8.0/non-static-static-call-fatal-error#:~:text=PHP%208.0%20no%20longer%20allows,notice%20in%20PHP%205%20versions.